### PR TITLE
Emit DTMF digits

### DIFF
--- a/aiortp/scheduler.pyx
+++ b/aiortp/scheduler.pyx
@@ -55,7 +55,6 @@ class DTMF:
         self.seq_iter = iter(self.sequence)
         self.current = next(self.seq_iter)
         self.cur_length = 0
-        # self.marked = True  TODO
 
         self.loop = loop
         self.future = future
@@ -66,6 +65,7 @@ class DTMF:
         self.timestamp = 20
         self.seq = 49710
         self.ssrc = 167411978
+        self.marked = True
 
     def __iter__(self):
         return self
@@ -74,11 +74,15 @@ class DTMF:
         if self.stopped:
             raise StopIteration()
 
+        if self.marked and self.cur_length:
+            self.marked = False
+
         # If we're off the end of the previous dtmf packet, get a new one
         if self.cur_length > self.tone_length:
             self.cur_length = 0
             try:
                 self.current = next(self.seq_iter)
+                self.marked = True
             except StopIteration:
                 self.stopped = True
                 if self.loop and self.future:
@@ -116,6 +120,7 @@ class AudioFile:
         self.timestamp = 20
         self.seq = 49709
         self.ssrc = 167411976
+        self.marked = False
 
     def __iter__(self):
         return self
@@ -224,7 +229,7 @@ class RTPScheduler:
                         'padding': 0,
                         'ext': 0,
                         'csrc.items': 0,
-                        'marker': 0,
+                        'marker': source.marked,
                         'p_type': source.format,
                         'seq': source.seq,
                         'timestamp': source.timestamp,

--- a/aiortp/scheduler.pyx
+++ b/aiortp/scheduler.pyx
@@ -212,7 +212,11 @@ class RTPScheduler:
 
             with self._lock:
                 for transport, source in self.streams.items():
-                    payload = next(source)
+                    try:
+                        payload = next(source)
+                    except StopIteration:
+                        continue
+
                     transport.sendto(pack_rtp({
                         'version': 2,
                         'padding': 0,

--- a/aiortp/scheduler.pyx
+++ b/aiortp/scheduler.pyx
@@ -85,8 +85,10 @@ class DTMF:
                     self.loop.call_soon_threadsafe(self.future.set_result, True)
                 raise StopIteration()
 
+        # Last three rtpevent messages should be marked as the end of event
+        end = bool(self.cur_length + 60 >= self.tone_length)
         event = pack_rtpevent({'event_id': self.current,
-                               'end_of_event': 0,
+                               'end_of_event': end,
                                'reserved': 0,
                                'volume': 10,
                                'duration': self.cur_length * 8})


### PR DESCRIPTION
With this code, we can now emit a sequence of arbitrary DTMF digits.

This is introducing a lot of technical debt:

- Scheduler will need to change to just recieve and manage raw packets, and not try to build the RTP packet before sending. This change will probably let us squeeze slightly better performance out of that loop too, as technically nothing says we can't precompute the dtmf or audio sample stream.

- Sources need to be better abstracted instead of the mess that is `dial` and `play`.